### PR TITLE
add spindle on pre and spindle off post commands

### DIFF
--- a/tests/test_machine_cmds.py
+++ b/tests/test_machine_cmds.py
@@ -173,6 +173,8 @@ class fakeOffset:
                         "g54": False,
                         "toolchange_pre": "",
                         "toolchange_post": "",
+                        "spindle_on_pre": "M07 (start mist)",
+                        "spindle_off_post": "M09 (stop coolant)",
                     },
                 },
                 "tablewidget": "",
@@ -189,6 +191,7 @@ G40 (No Offsets)
 G90 (Absolute-Mode)
 G64 P0.05
 M05 (Spindle off)
+M09 (stop coolant)
 F1000
 G00 Z20.000000
 
@@ -206,6 +209,7 @@ G00 Z20.000000
 (--------------------------------------------------)
 G00 Z20.0
 M06 T1
+M07 (start mist)
 M03 S10000 (Spindle on / CW)
 G04 P1 (pause in sec)
 G00 X22.000000 Y24.828427
@@ -265,6 +269,7 @@ G03 X-0.181071 Y8.008214 I1.987767 J-0.220863
 (- end -)
 G00 Z20.000000
 M05 (Spindle off)
+M09 (stop coolant)
 G00 X0.000000 Y0.000000
 M02
 """,

--- a/viaconstructor/output_plugins/gcode_grbl.py
+++ b/viaconstructor/output_plugins/gcode_grbl.py
@@ -157,10 +157,20 @@ class PostProcessorGcodeGrbl(PostProcessor):
         else:
             self.gcode.append("M05")
         self.tool_running = 0
+        if self.project["setup"]["machine"]["spindle_off_post"]:
+            for part in self.project["setup"]["machine"]["spindle_off_post"].split(
+                "\n"
+            ):
+                self.gcode.append(part)
 
     def spindle_cw(self, speed: int, pause: int = 1) -> None:
         if self.tool_running != 0 and self.tool_running == speed:
             return
+        if self.project["setup"]["machine"]["spindle_on_pre"]:
+                for part in self.project["setup"]["machine"]["spindle_on_pre"].split(
+                    "\n"
+                ):
+                    self.gcode.append(part)
         cmd = "M03"
         if self.speed != speed:
             self.speed = speed
@@ -178,6 +188,12 @@ class PostProcessorGcodeGrbl(PostProcessor):
         self.tool_running = self.speed
 
     def spindle_ccw(self, speed: int, pause: int = 1) -> None:
+        # no if self.tool_running != 0 and self.tool_running == speed test?
+        if self.project["setup"]["machine"]["spindle_on_pre"]:
+            for part in self.project["setup"]["machine"]["spindle_on_pre"].split(
+                "\n"
+            ):
+                self.gcode.append(part)
         cmd = "M04"
         if self.speed != speed:
             self.speed = speed

--- a/viaconstructor/output_plugins/gcode_grbl.py
+++ b/viaconstructor/output_plugins/gcode_grbl.py
@@ -167,10 +167,10 @@ class PostProcessorGcodeGrbl(PostProcessor):
         if self.tool_running != 0 and self.tool_running == speed:
             return
         if self.project["setup"]["machine"]["spindle_on_pre"]:
-                for part in self.project["setup"]["machine"]["spindle_on_pre"].split(
-                    "\n"
-                ):
-                    self.gcode.append(part)
+            for part in self.project["setup"]["machine"]["spindle_on_pre"].split(
+                "\n"
+            ):
+                self.gcode.append(part)
         cmd = "M03"
         if self.speed != speed:
             self.speed = speed

--- a/viaconstructor/output_plugins/gcode_linuxcnc.py
+++ b/viaconstructor/output_plugins/gcode_linuxcnc.py
@@ -156,10 +156,20 @@ class PostProcessorGcodeLinuxCNC(PostProcessor):
         else:
             self.gcode.append("M05")
         self.tool_running = 0
+        if self.project["setup"]["machine"]["spindle_off_post"]:
+            for part in self.project["setup"]["machine"]["spindle_off_post"].split(
+                "\n"
+            ):
+                self.gcode.append(part)
 
     def spindle_cw(self, speed: int, pause: int = 1) -> None:
         if self.tool_running != 0 and self.tool_running == speed:
             return
+        if self.project["setup"]["machine"]["spindle_on_pre"]:
+                for part in self.project["setup"]["machine"]["spindle_on_pre"].split(
+                    "\n"
+                ):
+                    self.gcode.append(part)
         cmd = "M03"
         if self.speed != speed:
             self.speed = speed
@@ -177,6 +187,12 @@ class PostProcessorGcodeLinuxCNC(PostProcessor):
         self.tool_running = self.speed
 
     def spindle_ccw(self, speed: int, pause: int = 1) -> None:
+        # no if self.tool_running != 0 and self.tool_running == speed test?
+        if self.project["setup"]["machine"]["spindle_on_pre"]:
+            for part in self.project["setup"]["machine"]["spindle_on_pre"].split(
+                "\n"
+            ):
+                self.gcode.append(part)
         cmd = "M04"
         if self.speed != speed:
             self.speed = speed

--- a/viaconstructor/output_plugins/gcode_linuxcnc.py
+++ b/viaconstructor/output_plugins/gcode_linuxcnc.py
@@ -166,10 +166,10 @@ class PostProcessorGcodeLinuxCNC(PostProcessor):
         if self.tool_running != 0 and self.tool_running == speed:
             return
         if self.project["setup"]["machine"]["spindle_on_pre"]:
-                for part in self.project["setup"]["machine"]["spindle_on_pre"].split(
-                    "\n"
-                ):
-                    self.gcode.append(part)
+            for part in self.project["setup"]["machine"]["spindle_on_pre"].split(
+                "\n"
+            ):
+                self.gcode.append(part)
         cmd = "M03"
         if self.speed != speed:
             self.speed = speed

--- a/viaconstructor/setupdefaults.py
+++ b/viaconstructor/setupdefaults.py
@@ -520,6 +520,18 @@ def setup_defaults(_) -> dict:
                 "title": _("toolchange post cmd"),
                 "tooltip": _("add gcode after tool-change"),
             },
+            "spindle_on_pre": {
+                "default": "",
+                "type": "mstr",
+                "title": _("spindle on pre cmd"),
+                "tooltip": _("add gcode before turning the spindle on"),
+            },
+            "spindle_off_post": {
+                "default": "",
+                "type": "mstr",
+                "title": _("spindle off post cmd"),
+                "tooltip": _("add gcode after turning the spindle off"),
+            },
             "comments": {
                 "default": True,
                 "type": "bool",


### PR DESCRIPTION
Hi,
I would like to control the mist cooling of my grblHAL based machine from the gcode file.
Adding commands before turning the spindle on and after turning the spindle off seems to be a generic way to allow everyone specify which coolant to use (mist or flood) and optionally run other custom commands.