### PR TITLE
allow to disable the toolchange

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,7 @@ bdist_deb:
 	python3 setup.py --command-packages=stdeb.command bdist_deb
 	ls -l deb_dist/*.deb
 
-bdist_rpm: 
+bdist_rpm:
 	python setup.py bdist_rpm
 
 appimage: bdist_deb

--- a/tests/test_machine_cmds.py
+++ b/tests/test_machine_cmds.py
@@ -173,6 +173,7 @@ class fakeOffset:
                         "unit": "mm",
                         "comments": True,
                         "g54": False,
+                        "supports_toolchange": True,
                         "toolchange_pre": "",
                         "toolchange_post": "",
                         "spindle_on_pre": "M07 (start mist)",

--- a/viaconstructor/machine_cmd.py
+++ b/viaconstructor/machine_cmd.py
@@ -751,7 +751,8 @@ def polylines2machine_cmd(project: dict, post: PostProcessor) -> str:
                     # toolchange
                     if project["setup"]["machine"]["mode"] == "mill":
                         post.move(z_pos=fast_move_z)
-                        post.tool(polyline.setup["tool"]["number"])
+                        if project["setup"]["machine"]["supports_toolchange"]:
+                            post.tool(polyline.setup["tool"]["number"])
                         post.spindle_cw(
                             polyline.setup["tool"]["speed"],
                             polyline.setup["tool"]["pause"],

--- a/viaconstructor/setupdefaults.py
+++ b/viaconstructor/setupdefaults.py
@@ -522,6 +522,12 @@ def setup_defaults(_) -> dict:
                 "title": _("machine supports g54"),
                 "tooltip": _("machine supports g54"),
             },
+            "supports_toolchange": {
+                "default": True,
+                "type": "bool",
+                "title": _("machine supports toolchange"),
+                "tooltip": _("machine supports toolchange"),
+            },
             "toolchange_pre": {
                 "default": "",
                 "type": "mstr",


### PR DESCRIPTION
The M06 tool changing command causes an error 40 (Status_GcodeToolChangePending) using grblHAL, UGS, and a machine providing no tool change mechanism.
This commit allows to disable the tool changing code (including the pre and post commands) in the Machine tab.
The Makefile change is just my editor removing trailing spaces.