### PR TITLE
set fixed height for QPlainTextEdit

### DIFF
--- a/viaconstructor/viaconstructor.py
+++ b/viaconstructor/viaconstructor.py
@@ -2189,6 +2189,7 @@ class ViaConstructor:  # pylint: disable=R0904
                     mlineedit.setPlainText(self.project["setup"][sname][ename])
                     mlineedit.setToolTip(helptext)
                     mlineedit.textChanged.connect(self.global_changed)  # type: ignore
+                    mlineedit.setFixedHeight(27)
                     hlayout.addWidget(mlineedit)
                     entry["widget"] = mlineedit
                 elif entry["type"] == "table":


### PR DESCRIPTION
This sets a fixed height for the QPlainTextEdits to save some space on smaller screens.
I am sure you have a better solution. Not sure if its possible to have a height of one line and expand them if there is more space?
Or maybe one line is too small?
![image](https://github.com/user-attachments/assets/8b321dfb-c440-442a-872d-3266003cca1d)


I guess for all can be entered multiple commands so I would also add an 's' at the end.